### PR TITLE
FEAT : 회원, 게시글, 신고 조회 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.0.16",
+        "axios": "^1.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-responsive": "^10.0.1",
-        "react-router-dom": "^7.8.0"
+        "react-router-dom": "^7.8.0",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1659,7 +1661,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1809,6 +1811,12 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1845,6 +1853,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1922,6 +1941,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2050,6 +2082,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2104,7 +2148,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2132,6 +2176,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2155,6 +2208,20 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2189,6 +2256,51 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2574,6 +2686,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2589,6 +2721,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -2624,10 +2772,46 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2656,6 +2840,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2673,11 +2869,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3205,6 +3427,15 @@
         "css-mediaquery": "^0.1.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3240,6 +3471,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3617,6 +3869,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4693,6 +4951,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.16",
+    "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-responsive": "^10.0.1",
-    "react-router-dom": "^7.8.0"
+    "react-router-dom": "^7.8.0",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,15 @@
+import client from "./client";
+
+export const postLogin = async ({ email, password }) => {
+    try {
+        const response = await client.post("/api/v1/auth/login", {
+            email: email,
+            password: password,
+          });
+        return response.data;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+}
+

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,94 @@
+import axios from "axios";
+
+const SERVER_URL = import.meta.env.VITE_BASE_URL;
+
+const client = axios.create({
+  baseURL: SERVER_URL,
+  withCredentials: true,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// 토큰 재발급 중복 요청 방지
+let isRefreshing = false;
+let failedQueue = [];
+
+const processQueue = (error, token = null) => {
+  failedQueue.forEach(prom => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  
+  failedQueue = [];
+};
+
+// 요청 인터셉터 추가
+client.interceptors.request.use(
+  (config) => {
+    //const { accessToken } = UserStore.getState();
+    const accessToken = localStorage.getItem("accessToken");
+    // console.log("🔑 요청 인터셉터 - 현재 액세스 토큰:", accessToken);
+    
+    if (accessToken) {
+      config.headers.set("Authorization", `Bearer ${accessToken}`);
+      // console.log("✅ Authorization 헤더 설정됨:", `Bearer ${accessToken.substring(0, 20)}...`);
+    } else {
+      console.log("❌ 액세스 토큰이 없음");
+    }
+    
+    return config;
+  },
+  (error) => {
+    console.error("❌ 요청 인터셉터 에러:", error);
+    return Promise.reject(error);
+  }
+);
+client.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    const status = error.response?.status;
+    const message = error.response?.data?.message;
+
+    console.log("응답 인터셉터 - 에러 상태:", status);
+    console.log("응답 인터셉터 - 에러 URL:", originalRequest?.url);
+
+    if ((status === 403 || status === 401) && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      // 1. 헤더에 새 토큰이 포함된 경우
+      const newAccessToken =
+        error.response.headers['new-access-token'] ||
+        error.response.headers['New-Access-Token'] ||
+        error.response.headers['X-New-Access-Token'];
+
+      if (newAccessToken) {
+        console.log("응답 헤더에서 새 토큰 발견, 재시도");
+
+        localStorage.setItem("accessToken", newAccessToken);
+
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return client(originalRequest);
+      }
+    }
+    // AlertModal이 있는 페이지는 에러 페이지로 이동하지 않고 모달이 뜨게
+    // if (status === 403) {
+    //   if (!window.location.pathname.includes("/recruitDetails")) {
+    //     window.location.href = "/forbidden"; 
+    //   }
+    // }
+
+    // 네트워크 에러 처리
+    if (error.code === "ERR_NETWORK") {
+      console.error("서버 연결 실패");
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default client;

--- a/src/api/member.js
+++ b/src/api/member.js
@@ -1,0 +1,20 @@
+import client from "./client";
+
+export const getMember = async ({ page, size, memberType, username, nickname }) => {
+    try {
+        const response = await client.get("/api/v1/admin/member", {
+            params: {
+              page: page,
+              size: size,
+              memberType: memberType,
+              username: username,
+              nickname: nickname,
+            },
+          });
+          return response.data;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+}
+

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -1,0 +1,18 @@
+import client from "./client";
+
+export const getPost = async ({ postType, writer, title, pageable }) => {
+    try {
+        const response = await client.get("/api/v1/admin/post", {
+            params: {
+                postType: postType,
+                writer: writer,
+                title: title,
+                pageable: pageable,
+            },
+        });
+        return response.data;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+}

--- a/src/api/report.js
+++ b/src/api/report.js
@@ -1,0 +1,19 @@
+import client from "./client";
+
+export const getReport = async ({ postType, startDate, endDate, nickname, pageable }) => {
+    try {
+        const response = await client.get("/api/v1/admin/report", {
+            params: {
+                postType: postType,
+                startDate: startDate,
+                endDate: endDate,
+                nickname: nickname,
+                pageable: pageable,
+            },
+        });
+        return response.data;
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+}

--- a/src/components/common/header.jsx
+++ b/src/components/common/header.jsx
@@ -1,8 +1,10 @@
 import { useLocation } from "react-router-dom";
+import { useUserStore } from "../../store/userStore";
 
 export default function Header() {
-  const location =useLocation();
-    const adminName = "태쿠자";
+  const location = useLocation();
+  const { nickname } = useUserStore();
+  const adminName = nickname || "관리자";
   const menus = [
     { label: "회원 관리", href: "/members" },
     { label: "게시글 관리", href: "/posts" },

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -3,14 +3,54 @@ import Input from "../components/common/input/input";
 import Button from "../components/common/button/button";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
+import { postLogin } from "../api/auth";
+import { useUserStore } from "../store/userStore";
 
 export default function Login() {
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showError, setShowError] = useState(false);
+  const { setUser, setAccessToken } = useUserStore();
 
-  const handleLoginClick = () => {  };
+  const handleLoginClick = async (e) => {
+    e.preventDefault();
+    
+    if (!email || !password) {
+      setShowError(true);
+      return;
+    }
+
+    try {
+      const response = await postLogin({ email, password });
+      console.log("로그인 성공:", response);
+      
+      
+      // 로그인 성공 시 userStore와 localStorage에 저장
+      if (response.result && response.result.accessToken) {
+        // userStore에 사용자 정보 저장
+        setUser({
+          memberId: response.result.memberId,
+          nickname: response.result.nickname,
+          roleType: response.result.roleType,
+        });
+        
+        // userStore에 액세스 토큰 저장
+        setAccessToken(response.result.accessToken);
+        
+        // localStorage에도 저장 (필요한 경우)
+        localStorage.setItem("accessToken", response.result.accessToken);
+        localStorage.setItem("memberId", response.result.memberId);
+        localStorage.setItem("nickname", response.result.nickname);
+        
+        // 로그인 성공 후 메인 페이지로 이동
+        navigate("/");
+      }
+    } catch (error) {
+      console.error("로그인 실패:", error);
+      setShowError(true);
+    }
+  };
 
 
 
@@ -55,7 +95,12 @@ export default function Login() {
           </button>
         </div>
         <div className="flex justify-center">
-          <Button btnText="로그인" width="w-1/2" />
+          <Button 
+            btnText="로그인" 
+            width="w-1/2" 
+            type="submit"
+            onClick={handleLoginClick}
+          />
         </div>
       </form>
     </AuthLayout>

--- a/src/pages/members.jsx
+++ b/src/pages/members.jsx
@@ -23,43 +23,31 @@ export default function Members() {
 const getMemberData = async () => {
   try {
     const response = await getMember({page: currentPage, size: pageSize});
-    console.log("회원 데이터:", response);
-    
-    // API 응답에서 실제 데이터 추출 (응답 구조에 따라 조정 필요)
-    if (response && response.data) {
-      setPaginationData(response.data.content || response.data);
-      setTotalPages(Math.ceil((response.data.totalElements || response.data.length) / pageSize));
-    }
+
+      if (response && response.result && response.result.content) {
+        console.log("API 응답 데이터:", response.result.content);
+        const memberData = response.result.content.map(member => ({
+          타입: member.roleType === "STUDENT" ? "학생" : member.roleType === "ADMIN" ? "관리자" : "기업",
+          이름: member.username,
+          닉네임: member.nickname,
+          이메일: member.email,
+          관리: member.isDeleted ? "탈퇴" : "활성"
+        }));
+        
+        setPaginationData(memberData);
+
+        const totalElements = response.result.totalElements || memberData.length;
+        setTotalPages(Math.ceil(totalElements / pageSize));
+      }
   } catch (error) {
     console.error("회원 데이터 조회 실패:", error);
-    // 에러 발생 시 더미 데이터 사용
-    setPaginationData(data.slice(currentPage * pageSize, (currentPage + 1) * pageSize));
-    setTotalPages(Math.ceil(data.length / pageSize));
+   
   }
 }
 
 useEffect(() => {
   getMemberData();
 }, [currentPage]);
-
-const data = [
-  { 타입: "학생", 이름: "김서현", 닉네임: "책벌레", 이메일: "booklover@mail.com", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "박지훈", 닉네임: "여행가", 이메일: "traveler@example.com", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "최민지", 닉네임: "코딩마스터", 이메일: "codingmaster@mail.com", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "이도현", 닉네임: "커피러버", 이메일: "coffee@demo.net", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "정예린", 닉네임: "음악매니아", 이메일: "musicfan@mail.com", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "오세훈", 닉네임: "야구소년", 이메일: "baseball@test.org", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "한수진", 닉네임: "그림쟁이", 이메일: "artist@mail.com", 관리: "탈퇴" },
-  { 타입: "기업", 이름: "스타트업A", 닉네임: "창업드림", 이메일: "startupA@mail.com", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "조민호", 닉네임: "맛집헌터", 이메일: "foodhunter@test.org", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "양지우", 닉네임: "캠핑족", 이메일: "camping@demo.net", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "서가영", 닉네임: "드라마퀸", 이메일: "dramaqueen@mail.com", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "홍승우", 닉네임: "헬스매니아", 이메일: "fitness@test.org", 관리: "탈퇴" },
-  { 타입: "기업", 이름: "테크기업B", 닉네임: "혁신리더", 이메일: "techB@mail.com", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "배유진", 닉네임: "고양이집사", 이메일: "catlover@test.org", 관리: "탈퇴" },
-  { 타입: "학생", 이름: "임하늘", 닉네임: "사진작가", 이메일: "photographer@demo.net", 관리: "탈퇴" }
-]
-
 
   const handlePageChange = (newPage) => {
     setCurrentPage(newPage);
@@ -77,10 +65,7 @@ const data = [
     console.log("검색어:", value);
   };
 
-  useEffect( () => {
-    setPaginationData(data.slice(currentPage*pageSize , (currentPage+1)*pageSize));
-    setTotalPages(Math.ceil(data.length/pageSize));
-  },[currentPage]);
+  // 이 useEffect는 제거 - getMemberData에서 처리함
   
   return (
     <AdminLayout

--- a/src/pages/members.jsx
+++ b/src/pages/members.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { getMember } from "../api/member";
 import AdminLayout from "../components/layout/adminLayout";
 import Table from "../components/common/table";
 import Pagination from "../components/common/pagination";
@@ -18,6 +19,29 @@ export default function Members() {
   { key: "이메일", value: "이메일" },
   { key: "관리", value: "관리" },
 ];
+
+const getMemberData = async () => {
+  try {
+    const response = await getMember({page: currentPage, size: pageSize});
+    console.log("회원 데이터:", response);
+    
+    // API 응답에서 실제 데이터 추출 (응답 구조에 따라 조정 필요)
+    if (response && response.data) {
+      setPaginationData(response.data.content || response.data);
+      setTotalPages(Math.ceil((response.data.totalElements || response.data.length) / pageSize));
+    }
+  } catch (error) {
+    console.error("회원 데이터 조회 실패:", error);
+    // 에러 발생 시 더미 데이터 사용
+    setPaginationData(data.slice(currentPage * pageSize, (currentPage + 1) * pageSize));
+    setTotalPages(Math.ceil(data.length / pageSize));
+  }
+}
+
+useEffect(() => {
+  getMemberData();
+}, [currentPage]);
+
 const data = [
   { 타입: "학생", 이름: "김서현", 닉네임: "책벌레", 이메일: "booklover@mail.com", 관리: "탈퇴" },
   { 타입: "학생", 이름: "박지훈", 닉네임: "여행가", 이메일: "traveler@example.com", 관리: "탈퇴" },
@@ -56,7 +80,7 @@ const data = [
   useEffect( () => {
     setPaginationData(data.slice(currentPage*pageSize , (currentPage+1)*pageSize));
     setTotalPages(Math.ceil(data.length/pageSize));
-  },[currentPage,data]);
+  },[currentPage]);
   
   return (
     <AdminLayout

--- a/src/pages/reports.jsx
+++ b/src/pages/reports.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import AdminLayout from "../components/layout/adminLayout";
 import Table from "../components/common/table";
 import Pagination from "../components/common/pagination";
+import { getReport } from "../api/report";
 
 export default function Reports() {
   const [typeFilter, setTypeFilter] = useState("recruit");
@@ -21,6 +22,15 @@ export default function Reports() {
     { key: "사유", value: "사유" },
     { key: "작성자", value: "작성자" },
   ];
+
+  const getReportData = async () => {
+    const response = await getReport({page: currentPage, size: pageSize});
+    console.log("API 응답 데이터:", response);
+  }
+
+  useEffect(() => {
+    getReportData();
+  }, [currentPage]);
 
   // 더미 데이터
   const data = [
@@ -69,7 +79,7 @@ export default function Reports() {
   useEffect(() => {
     setPaginationData(data.slice(currentPage * pageSize, (currentPage + 1) * pageSize));
     setTotalPages(Math.ceil(data.length / pageSize));
-  }, [currentPage, data]);
+  }, [currentPage]);
 
   return (
     <AdminLayout

--- a/src/store/userStore.js
+++ b/src/store/userStore.js
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+export const useUserStore = create((set) => ({
+  memberId: null,
+  nickname: null,
+  accessToken: null,
+  
+  setUser: (userData) => set({
+    memberId: userData.memberId,
+    nickname: userData.nickname,
+    roleType: userData.roleType,
+  }),
+  
+  setAccessToken: (token) => set({
+    accessToken: token,
+  }),
+  
+  clearUser: () => set({
+    memberId: null,
+    nickname: null,
+    accessToken: null,
+    roleType: null,
+  }),
+})); 


### PR DESCRIPTION
## 작업 내용
회원 목록 조회, 게시글 목록 조회, 신고 목록 조회 API 를 연동하였습니다.

아직 관리자 페이지 로그인 API가 분리되지 않아 기존 스프 로그인 API를 사용해서 토큰 발급후에 연동
-> 추후 로그인 API 수정 시 바꿔야 함!

또한 데이터 필터링은 아직 작업하지 않아 모든 페이지는 전체 조회만 가능합니다.